### PR TITLE
Use Hamiltonians on GPU

### DIFF
--- a/src/BitStringAddresses/bitstring.jl
+++ b/src/BitStringAddresses/bitstring.jl
@@ -579,18 +579,18 @@ end
 end
 
 function bose_excitation(
-    bs::BitString, creations::NTuple{N}, destructions::NTuple{N}
-) where N
+    ::Type{T}, bs::BitString, creations::NTuple{N}, destructions::NTuple{N}
+) where {T, N}
     # We start by computing the value. This is where the check if the move is even legal
     # is done.
     creations_rev = reverse(creations)
     value = bose_excitation_value(creations_rev, reverse(destructions))
     if iszero(value)
-        return bs, 0.0
+        return bs, zero(T)
     else
         # Now that we know the value and that the move is legal, we can apply the moves
         # without worrying about doing something weird.
-        return bose_move_particles(bs, creations_rev, destructions), √value
+        return bose_move_particles(bs, creations_rev, destructions), √T(value)
     end
 end
 
@@ -778,17 +778,17 @@ function fermi_excitation(
     for i in ND:-1:1
         d = destructions[i].mode
         bs, x, val = _flip_and_count(bs, UInt(d - 0x1))
-        val && return orig_bs, 0.0
+        val && return orig_bs, 0
         count += x
     end
     for i in NC:-1:1
         c = creations[i].mode
         bs, x, val = _flip_and_count(bs, UInt(c - 0x1))
-        !val && return orig_bs, 0.0
+        !val && return orig_bs, 0
         count += x
     end
 
-    return bs, ifelse(iseven(count), 1.0, -1.0)
+    return bs, ifelse(iseven(count), 1, -1)
 end
 
 function Base.iterate(o::FermiOccupiedModes{<:Any,<:BitString})

--- a/src/BitStringAddresses/bosefs.jl
+++ b/src/BitStringAddresses/bosefs.jl
@@ -351,11 +351,11 @@ end
 
 # find_occupied_mode provided by generic implementation
 
-function excitation(b::B, creations::NTuple{C}, destructions::NTuple{C}) where {B<:BoseFS, C}
-    new_bs, val = bose_excitation(b.bs, creations, destructions)
+function excitation(::Type{T}, b::B, creations::NTuple{C}, destructions::NTuple{C}) where {T, B<:BoseFS, C}
+    new_bs, val = bose_excitation(T, b.bs, creations, destructions)
     return B(new_bs), val # type doesn't change
 end
-function excitation(b::BoseFS, c::NTuple{C}, d::NTuple{D}) where {C, D}
+function excitation(::Type, ::BoseFS, ::NTuple{C}, ::NTuple{D}) where {C,D}
     throw(ArgumentError("number of creations and destructions must be equal, got $C and $D"))
 end
 
@@ -662,32 +662,34 @@ end
 end
 
 function excitation(
+    ::Type{T},
     fs::BoseFS{missing,M,S},
     c::NTuple{<:Any,Int},
     d::NTuple{<:Any,Int}
-) where {M,S<:SVector{M,<:Unsigned}}
+) where {T,M,S<:SVector{M,<:Unsigned}}
     onr = fs.bs
-    accumulator = 1.0 # to avoid overflow
+    accumulator = one(T) # to avoid overflow
     for i in d
         onr, val = _destroy(onr, i)
-        iszero(val) && return fs, 0.0 # return early if invalid; efficient according to benchmarks
+        iszero(val) && return fs, zero(T) # return early if invalid; efficient according to benchmarks
         accumulator *= val
     end
     for i in c
         onr, val = _create(onr, i)
         accumulator *= val
-        iszero(val) && return fs, 0.0
+        iszero(val) && return fs, zero(T)
     end
     return typeof(fs)(onr), √accumulator
 end
 function excitation(
+    ::Type{T},
     fs::BoseFS{missing},
     c::NTuple{N1,BoseFSIndex},
     d::NTuple{N2,BoseFSIndex}
-) where {N1,N2}
+) where {T, N1,N2}
     creations = ntuple(i -> c[i].mode, Val(N1)) # convert BoseFSIndex to mode number
     destructions = ntuple(i -> d[i].mode, Val(N2))
-    return excitation(fs, creations, destructions)
+    return excitation(T, fs, creations, destructions)
 end
 
 # `SingleComponentFockAddress` interface for BoseFS{missing}

--- a/src/BitStringAddresses/bosefs.jl
+++ b/src/BitStringAddresses/bosefs.jl
@@ -357,7 +357,7 @@ function excitation(
     new_bs, val = bose_excitation(T, b.bs, creations, destructions)
     return B(new_bs), val # type doesn't change
 end
-function excitation(::Type, ::BoseFS, ::NTuple{C}, ::NTuple{D}) where {C,D}
+function excitation(::Type{<:AbstractFloat}, ::BoseFS, ::NTuple{C}, ::NTuple{D}) where {C,D}
     throw(ArgumentError("number of creations and destructions must be equal, got $C and $D"))
 end
 
@@ -665,10 +665,10 @@ end
 
 function excitation(
     ::Type{T},
-    fs::BoseFS{missing,M,S},
+    fs::BoseFS{missing},
     c::NTuple{<:Any,Int},
     d::NTuple{<:Any,Int}
-) where {T <: AbstractFloat, M, S<:SVector{M,<:Unsigned}}
+) where {T <: AbstractFloat}
     onr = fs.bs
     accumulator = one(T) # to avoid overflow
     for i in d

--- a/src/BitStringAddresses/bosefs.jl
+++ b/src/BitStringAddresses/bosefs.jl
@@ -351,7 +351,9 @@ end
 
 # find_occupied_mode provided by generic implementation
 
-function excitation(::Type{T}, b::B, creations::NTuple{C}, destructions::NTuple{C}) where {T, B<:BoseFS, C}
+function excitation(
+    ::Type{T}, b::B, creations::NTuple{C}, destructions::NTuple{C}
+) where {T <: AbstractFloat, B<:BoseFS, C}
     new_bs, val = bose_excitation(T, b.bs, creations, destructions)
     return B(new_bs), val # type doesn't change
 end
@@ -666,7 +668,7 @@ function excitation(
     fs::BoseFS{missing,M,S},
     c::NTuple{<:Any,Int},
     d::NTuple{<:Any,Int}
-) where {T,M,S<:SVector{M,<:Unsigned}}
+) where {T <: AbstractFloat, M, S<:SVector{M,<:Unsigned}}
     onr = fs.bs
     accumulator = one(T) # to avoid overflow
     for i in d
@@ -686,7 +688,7 @@ function excitation(
     fs::BoseFS{missing},
     c::NTuple{N1,BoseFSIndex},
     d::NTuple{N2,BoseFSIndex}
-) where {T, N1,N2}
+) where {T <: AbstractFloat, N1, N2}
     creations = ntuple(i -> c[i].mode, Val(N1)) # convert BoseFSIndex to mode number
     destructions = ntuple(i -> d[i].mode, Val(N2))
     return excitation(T, fs, creations, destructions)

--- a/src/BitStringAddresses/fermifs.jl
+++ b/src/BitStringAddresses/fermifs.jl
@@ -149,13 +149,13 @@ function print_address(io::IO, f::FermiFS{N,M}; compact=false) where {N,M}
 end
 
 function excitation(
-    a::FermiFS{N,M,S}, creations::NTuple{NC}, destructions::NTuple{ND}
-) where {N,M,S,NC,ND}
+    ::Type{T}, a::FermiFS{N,M,S}, creations::NTuple{NC}, destructions::NTuple{ND}
+) where {T, N, M, S, NC, ND}
     if NC != ND && !ismissing(N)
         throw(ArgumentError("number of creations and destructions must be equal, got $NC and $ND"))
     end
     new_bs, value = fermi_excitation(a.bs, creations, destructions)
-    return FermiFS{N,M,S}(new_bs), value # carries sign, different from HardcoreBoseFS
+    return FermiFS{N,M,S}(new_bs), T(value) # carries sign, different from HardcoreBoseFS
 end
 
 # joint functions for FermiFS and HardcoreBoseFS

--- a/src/BitStringAddresses/fermifs.jl
+++ b/src/BitStringAddresses/fermifs.jl
@@ -150,7 +150,7 @@ end
 
 function excitation(
     ::Type{T}, a::FermiFS{N,M,S}, creations::NTuple{NC}, destructions::NTuple{ND}
-) where {T, N, M, S, NC, ND}
+) where {T <: AbstractFloat, N, M, S, NC, ND}
     if NC != ND && !ismissing(N)
         throw(ArgumentError("number of creations and destructions must be equal, got $NC and $ND"))
     end

--- a/src/BitStringAddresses/fockaddress.jl
+++ b/src/BitStringAddresses/fockaddress.jl
@@ -174,7 +174,12 @@ See also [`find_occupied_mode`](@ref), [`occupied_modes`](@ref).
 unoccupied_modes
 
 """
-    excitation(addr::SingleComponentFockAddress, creations::NTuple, destructions::NTuple)
+    excitation(
+        [::Type{T},]
+        addr::SingleComponentFockAddress,
+        creations::NTuple,
+        destructions::NTuple
+    ) -> (::SingleComponentFockAddress, ::T)
 
 Generate an excitation on address `addr` by applying `creations` and `destructions`, which
 are tuples of the appropriate address indices (i.e. [`BoseFSIndex`](@ref) for
@@ -189,7 +194,8 @@ Returns the new address `f'` and the factor `α`. The value of `α` is given by 
 root of the product of mode occupations before destruction and after creation. If the
 excitation is illegal, returns an arbitrary address and the value `0.0`. Note that the
 number of particles may change if the number of creation and destruction operators is not
-equal and `num_particles(typeof(addr))` is `missing`.
+equal and `num_particles(typeof(addr))` is `missing`. A type `T <: AbstractFloat` can be
+specified to set the type of the returned value of `α`. The default is `Float64`.
 See examples below.
 
 # Example
@@ -216,8 +222,8 @@ BoseFS{missing}(1, 2, 3)
 julia> num_particles(s)
 6
 
-julia> es, α = excitation(s, (1,1), (3,))
-(BoseFS{missing}(3, 2, 2), 4.242640687119285)
+julia> es, α = excitation(Float32, s, (1,1), (3,))
+(BoseFS{missing}(3, 2, 2), 4.2426405f0)
 
 julia> num_particles(es)
 7
@@ -225,7 +231,9 @@ julia> num_particles(es)
 
 See [`SingleComponentFockAddress`](@ref).
 """
-excitation
+function excitation(addr::SingleComponentFockAddress, creations::NTuple, destructions::NTuple)
+    return excitation(Float64, addr, creations, destructions)
+end
 
 
 """
@@ -729,8 +737,8 @@ to_bose_onr
 
 """
     bose_excitation(
-        bs::B, creations::NTuple{N,BoseFSIndex}, destructions::NTuple{N,BoseFSIndex}
-    ) -> Tuple{B,Float64}
+        ::Type{T}, bs::B, creations::NTuple{N,BoseFSIndex}, destructions::NTuple{N,BoseFSIndex}
+    ) -> Tuple{B, T}
 
 Perform excitation as if `bs` was a bosonic address. See also
 [`bose_excitation_value`](@ref).
@@ -835,7 +843,7 @@ fermi_find_mode
 """
     fermi_excitation(
         bs::B, creations::NTuple{N,FermiFSIndex}, destructions::NTuple{N,FermiFSIndex}
-    ) → Tuple{B,Float64}
+    ) → Tuple{B, Int}
 
 Perform excitation as if `bs` was a fermionic address.
 

--- a/src/BitStringAddresses/hardcorebosefs.jl
+++ b/src/BitStringAddresses/hardcorebosefs.jl
@@ -143,13 +143,13 @@ function print_address(io::IO, f::HardcoreBoseFS{N,M}; compact=false) where {N,M
 end
 
 function excitation(
-    a::HardcoreBoseFS{N,M,S}, creations::NTuple{NC}, destructions::NTuple{ND}
-) where {N,M,S,NC,ND}
+    ::Type{T}, a::HardcoreBoseFS{N,M,S}, creations::NTuple{NC}, destructions::NTuple{ND}
+) where {T, N, M, S, NC, ND}
     if NC != ND && !ismissing(N)
         throw(ArgumentError("number of creations and destructions must be equal, got $NC and $ND"))
     end
     new_bs, value = fermi_excitation(a.bs, creations, destructions)
-    return HardcoreBoseFS{N,M,S}(new_bs), abs(value) # different from FermiFS, no sign
+    return HardcoreBoseFS{N,M,S}(new_bs), T(abs(value)) # different from FermiFS, no sign
 end
 
 # See "fermifs.jl" for other function definitions for HardcoreBoseFS.

--- a/src/BitStringAddresses/hardcorebosefs.jl
+++ b/src/BitStringAddresses/hardcorebosefs.jl
@@ -144,7 +144,7 @@ end
 
 function excitation(
     ::Type{T}, a::HardcoreBoseFS{N,M,S}, creations::NTuple{NC}, destructions::NTuple{ND}
-) where {T, N, M, S, NC, ND}
+) where {T <: AbstractFloat, N, M, S, NC, ND}
     if NC != ND && !ismissing(N)
         throw(ArgumentError("number of creations and destructions must be equal, got $NC and $ND"))
     end

--- a/src/BitStringAddresses/sortedparticlelist.jl
+++ b/src/BitStringAddresses/sortedparticlelist.jl
@@ -181,14 +181,14 @@ bose_num_occupied_modes(ss::SortedParticleList) = length(ss)
 bose_find_mode(ss::SortedParticleList, n) = find_mode(ss, n)
 
 @inline function bose_excitation(
-    ss::SortedParticleList{N,M,T}, creations, destructions
-) where {N,M,T}
+    ::Type{T}, ss::SortedParticleList, creations, destructions
+) where {T}
     creations_rev = reverse(creations)
     value = bose_excitation_value(creations_rev, destructions)
     if iszero(value)
-        return ss, 0.0
+        return ss, zero(T)
     else
-        return move_particles(ss, creations_rev, destructions), √value
+        return move_particles(ss, creations_rev, destructions), √T(value)
     end
 end
 
@@ -236,7 +236,7 @@ order. Will return 0 if move is illegal.
 
 Note that this function only works on indices obtained from a [`SortedParticleList`](@ref).
 """
-@inline fermi_excitation_value_spl(::Tuple{}, ::Tuple{}) = 1.0
+@inline fermi_excitation_value_spl(::Tuple{}, ::Tuple{}) = 1
 @inline function fermi_excitation_value_spl((c, cs...), ::Tuple{})
     cs = map(_fix_pos_create(c), cs)
     return fermi_excitation_value_spl(cs, ()) * ifelse(isodd(c.offset), -1, 1) * (c.occnum == 0)
@@ -255,15 +255,15 @@ function fermi_find_mode(ss::SortedParticleList, ns::Tuple)
 end
 
 @inline function fermi_excitation(
-    ss::SortedParticleList{N,M,T}, creations::NTuple{K}, destructions::NTuple{K}
-) where {N,M,T,K}
+    ss::SortedParticleList, creations::NTuple{K}, destructions::NTuple{K}
+) where {T,K}
     creations_rev = reverse(creations)
     destructions_rev = reverse(destructions)
     value = fermi_excitation_value_spl(creations_rev, destructions_rev)
     if iszero(value)
-        return ss, 0.0
+        return ss, value
     else
-        return move_particles(ss, creations_rev, destructions), float(value)
+        return move_particles(ss, creations_rev, destructions), value
     end
 end
 

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -19,7 +19,7 @@ if not provided. Set `T` to `Float32` for single precision, e.g. when using GPUs
 
 * `p=0.0`: the total momentum ``p``.
 * `v=1.0`: the coupling strength ``v``.
-* `electron_mass=0.5`: the particle mass ``m``.
+* `two_m=1.0`: twice the particle mass ``2m``.
 * `omega=1.0`: the oscillation frequency of the phonons ``ω``.
 * `l=1.0`: the box size in real space ``l``. Provides scale parameter of the momentum
     lattice.
@@ -35,7 +35,7 @@ julia> fs = BoseFS{missing}(0,0,0)
 BoseFS{missing}(0, 0, 0)
 
 julia> ham = FroehlichPolaron(fs; v=0.5)
-FroehlichPolaron(fs"|0 0 0⟩{}"; v=0.5, electron_mass=0.5, omega=1.0, l=1.0, p=0.0, mode_cutoff=255)
+FroehlichPolaron(fs"|0 0 0⟩{}"; v=0.5, two_m=1.0, omega=1.0, l=1.0, p=0.0, mode_cutoff=255)
 
 julia> dimension(ham)
 16777216
@@ -58,7 +58,7 @@ struct FroehlichPolaron{
 } <: AbstractHamiltonian{T}
     addr::A
     v::T
-    electron_mass::T
+    two_m::T
     omega::T
     l::T
     p::T
@@ -70,23 +70,23 @@ end
 function FroehlichPolaron{T}(
     addr::BoseFS{missing,M,SVector{M,AT}};
     v=1,
-    electron_mass=1//2,
+    two_m=1,
     omega=1,
     l=1,
     p=0,
     momentum_cutoff=nothing,
     mode_cutoff=nothing,
-    mass=nothing, # deprecated keyword, use `electron_mass` instead
+    mass=nothing, # deprecated keyword, use `two_m` instead
 ) where {T,M,AT}
     if l ≤ 0
         throw(ArgumentError("l must be positive"))
     end
 
     if !isnothing(mass)
-        @warn "The keyword argument `mass` is deprecated. Use `electron_mass` instead."
-        electron_mass = mass/2
+        @warn "The keyword argument `mass` is deprecated. Use `two_m` instead."
+        two_m = mass
     end
-    v, p, electron_mass, omega, l = T.((v, p, electron_mass, omega, l))
+    v, p, two_m, omega, l = T.((v, p, two_m, omega, l))
 
     step = T(2π/M)
     if isodd(M)
@@ -112,25 +112,25 @@ function FroehlichPolaron{T}(
     if _exceed_mode_cutoff(mode_cutoff, addr)
         throw(ArgumentError("Starting address cannot have occupations that exceed mode_cutoff"))
     end
-    return FroehlichPolaron(addr, v, electron_mass, omega, l, p, ks, momentum_cutoff, mode_cutoff)
+    return FroehlichPolaron(addr, v, two_m, omega, l, p, ks, momentum_cutoff, mode_cutoff)
 end
 function FroehlichPolaron(
     addr::BoseFS{missing};
     v=1,
-    electron_mass=1//2,
+    two_m=1,
     omega=1,
     l=1,
     p=0,
-    mass=nothing, # deprecated keyword, use `electron_mass` instead
+    mass=nothing, # deprecated keyword, use `two_m` instead
     kwargs...
 )
     if !isnothing(mass)
-        @warn "The keyword argument `mass` is deprecated. Use `electron_mass` instead."
-        electron_mass = mass/2
+        @warn "The keyword argument `mass` is deprecated. Use `two_m` instead."
+        two_m = mass
     end
 
-    T = float(promote_type(typeof(v), typeof(electron_mass), typeof(omega), typeof(l), typeof(p)))
-    return FroehlichPolaron{T}(addr; v=v, electron_mass=electron_mass, omega=omega, l=l, p=p, kwargs...)
+    T = float(promote_type(typeof(v), typeof(two_m), typeof(omega), typeof(l), typeof(p)))
+    return FroehlichPolaron{T}(addr; v=v, two_m=two_m, omega=omega, l=l, p=p, kwargs...)
 end
 
 function Base.show(io::IO, h::FroehlichPolaron)
@@ -138,7 +138,7 @@ function Base.show(io::IO, h::FroehlichPolaron)
     print(io, "FroehlichPolaron")
     eltype(h) === Float64 || print(io, "{$(eltype(h))}")
     print(io, "($compact_addr; ")
-    print(io, "v=$(h.v), electron_mass=$(h.electron_mass), omega=$(h.omega), l=$(h.l), p=$(h.p), ")
+    print(io, "v=$(h.v), two_m=$(h.two_m), omega=$(h.omega), l=$(h.l), p=$(h.p), ")
     isnothing(h.momentum_cutoff) || print(io, "momentum_cutoff=$(h.momentum_cutoff), ")
     print(io, "mode_cutoff=$(h.mode_cutoff))")
 end
@@ -155,7 +155,7 @@ LOStructure(::Type{<:FroehlichPolaron{<:Real}}) = IsHermitian()
 function diagonal_element(h::FroehlichPolaron{<:Any,M}, addr::BoseFS{missing,M}) where {M}
     map = onr(addr)
     p_f = dot(h.ks, map)
-    return h.omega * num_particles(addr) + (h.p - p_f)^2 / (2 * h.electron_mass)
+    return h.omega * num_particles(addr) + (h.p - p_f)^2 / h.two_m
 end
 
 function num_offdiagonals(::FroehlichPolaron{<:Any,M}, ::BoseFS{missing,M}) where {M}

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -81,6 +81,7 @@ function FroehlichPolaron{T}(
     if l ≤ 0
         throw(ArgumentError("l must be positive"))
     end
+    T <: AbstractFloat || throw(ArgumentError("T must be a subtype of AbstractFloat"))
 
     if !isnothing(mass)
         @warn "The keyword argument `mass` is deprecated. Use `two_m` instead."

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -1,5 +1,5 @@
 """
-    FroehlichPolaron(address::BoseFS{missing,M}; kwargs...) <: AbstractHamiltonian
+    FroehlichPolaron{T}(address::BoseFS{missing,M}; kwargs...) <: AbstractHamiltonian{T}
 
 
 The Froehlich polaron Hamiltonian for a 1D lattice with `M` momentum modes is given by
@@ -12,6 +12,8 @@ where ``p`` is the total momentum, ``p̂_f = Σ_k k âₖ^† âₖ`` is the m
 bosons, and ``k`` part of the momentum lattice with separation ``2π/l``. ``N̂`` is the number
 operator for the bosons.
 
+Setting the type parameter `T` is optional and will be inferred from the keyword arguments
+if not provided. Set `T` to `Float32` for single precision, e.g. when using GPUs.
 
 # Keyword Arguments
 
@@ -67,11 +69,11 @@ end
 
 function FroehlichPolaron{T}(
     addr::BoseFS{missing,M,SVector{M,AT}};
-    v=1.0,
-    mass=1.0,
-    omega=1.0,
-    l=1.0,
-    p=0.0,
+    v=1,
+    mass=1,
+    omega=1,
+    l=1,
+    p=0,
     momentum_cutoff=nothing,
     mode_cutoff=nothing,
 ) where {T,M,AT}
@@ -109,11 +111,11 @@ function FroehlichPolaron{T}(
 end
 function FroehlichPolaron(
     addr::BoseFS{missing};
-    v=1.0,
-    mass=1.0,
-    omega=1.0,
-    l=1.0,
-    p=0.0,
+    v=1,
+    mass=1,
+    omega=1,
+    l=1,
+    p=0,
     kwargs...
 )
     T = float(promote_type(typeof(v), typeof(mass), typeof(omega), typeof(l), typeof(p)))

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -143,7 +143,7 @@ LOStructure(::Type{<:FroehlichPolaron{<:Real}}) = IsHermitian()
 
 function diagonal_element(h::FroehlichPolaron{<:Any,M}, addr::BoseFS{missing,M}) where {M}
     map = onr(addr)
-    p_f = dot(h.ks,map)
+    p_f = dot(h.ks, map)
     return h.omega * num_particles(addr) + (h.p - p_f)^2 / h.mass
 end
 
@@ -162,23 +162,24 @@ function get_offdiagonal(h::FroehlichPolaron{T,M,<:Any,T}, addr::BoseFS{missing,
 
     new_p_tot = dot(h.ks, onr(naddress))
     if abs(new_p_tot) > h.momentum_cutoff # check if momentum of new address exceeds momentum_cutoff
-        return addr, 0.0
+        return addr, zero(T)
     else
         return naddress, value
     end
 end
 
 function _froehlich_offdiag(h, addr::BoseFS{missing,M},chosen) where {M}
+    T = eltype(h)
     if chosen ≤ M # assign first M indices to creations
         if onr(addr)[chosen] ≥ h.mode_cutoff # check whether occupation exceeds cutoff
-            return addr, 0.0
+            return addr, zero(T)
         else
-            naddress, value = excitation(addr, (chosen,), ())
+            naddress, value = excitation(T, addr, (chosen,), ())
             return naddress, - h.v * value
         end
     else # remaining indices are destructions
 
-        naddress, value = excitation(addr, (), (chosen - M,))
+        naddress, value = excitation(T, addr, (), (chosen - M,))
         return naddress, - h.v * value
     end
 end

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -65,7 +65,7 @@ struct FroehlichPolaron{
     mode_cutoff::Int
 end
 
-function FroehlichPolaron(
+function FroehlichPolaron{T}(
     addr::BoseFS{missing,M,SVector{M,AT}};
     v=1.0,
     mass=1.0,
@@ -74,24 +74,24 @@ function FroehlichPolaron(
     p=0.0,
     momentum_cutoff=nothing,
     mode_cutoff=nothing,
-) where {M,AT}
+) where {T,M,AT}
     if l ≤ 0
         throw(ArgumentError("l must be positive"))
     end
 
-    v, p, mass, omega, l = promote(float(v), float(p), float(mass), float(omega), float(l))
+    v, p, mass, omega, l = T.((v, p, mass, omega, l))
 
-    step = typeof(v)(2π/M)
+    step = T(2π/M)
     if isodd(M)
-        start = -π*(1+1/M) + step
+        start = -π * T(1 + 1/M) + step
     else
         start = -π + step
     end
     kr = (M/l)*range(start; step = step, length = M)
-    ks = SVector{M,typeof(v)}(kr)
+    ks = SVector{M,T}(kr)
 
     if !isnothing(momentum_cutoff)
-        momentum_cutoff = typeof(v)(momentum_cutoff)
+        momentum_cutoff = T(momentum_cutoff)
         momentum = dot(ks,onr(addr))
         if abs(momentum) > momentum_cutoff
             throw(ArgumentError("Starting address has momentum $momentum which cannot exceed momentum_cutoff $momentum_cutoff"))
@@ -107,14 +107,27 @@ function FroehlichPolaron(
     end
     return FroehlichPolaron(addr, v, mass, omega, l, p, ks, momentum_cutoff, mode_cutoff)
 end
+function FroehlichPolaron(
+    addr::BoseFS{missing};
+    v=1.0,
+    mass=1.0,
+    omega=1.0,
+    l=1.0,
+    p=0.0,
+    kwargs...
+)
+    T = float(promote_type(typeof(v), typeof(mass), typeof(omega), typeof(l), typeof(p)))
+    return FroehlichPolaron{T}(addr; v=v, mass=mass, omega=omega, l=l, p=p, kwargs...)
+end
 
 function Base.show(io::IO, h::FroehlichPolaron)
     compact_addr = repr(h.addr, context=:compact => true) # compact print address
-    print(io, "FroehlichPolaron($compact_addr; ")
+    print(io, "FroehlichPolaron")
+    eltype(h) === Float64 || print(io, "{$(eltype(h))}")
+    print(io, "($compact_addr; ")
     print(io, "v=$(h.v), mass=$(h.mass), omega=$(h.omega), l=$(h.l), p=$(h.p), ")
     isnothing(h.momentum_cutoff) || print(io, "momentum_cutoff=$(h.momentum_cutoff), ")
     print(io, "mode_cutoff=$(h.mode_cutoff))")
-
 end
 
 function starting_address(h::FroehlichPolaron)

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -5,7 +5,7 @@
 The Froehlich polaron Hamiltonian for a 1D lattice with `M` momentum modes is given by
 
 ```math
-H = (p̂_f - p)^2/m + ωN̂ - v Σₖ(âₖ^† + â₋ₖ)
+H = (p̂_f - p)^2/2m + ωN̂ - v Σₖ(âₖ^† + â₋ₖ)
 ```
 
 where ``p`` is the total momentum, ``p̂_f = Σ_k k âₖ^† âₖ`` is the momentum operator for the
@@ -19,7 +19,7 @@ if not provided. Set `T` to `Float32` for single precision, e.g. when using GPUs
 
 * `p=0.0`: the total momentum ``p``.
 * `v=1.0`: the coupling strength ``v``.
-* `mass=1.0`: the particle mass ``m``.
+* `electron_mass=0.5`: the particle mass ``m``.
 * `omega=1.0`: the oscillation frequency of the phonons ``ω``.
 * `l=1.0`: the box size in real space ``l``. Provides scale parameter of the momentum
     lattice.
@@ -35,7 +35,7 @@ julia> fs = BoseFS{missing}(0,0,0)
 BoseFS{missing}(0, 0, 0)
 
 julia> ham = FroehlichPolaron(fs; v=0.5)
-FroehlichPolaron(fs"|0 0 0⟩{}"; v=0.5, mass=1.0, omega=1.0, l=1.0, p=0.0, mode_cutoff=255)
+FroehlichPolaron(fs"|0 0 0⟩{}"; v=0.5, electron_mass=0.5, omega=1.0, l=1.0, p=0.0, mode_cutoff=255)
 
 julia> dimension(ham)
 16777216
@@ -58,7 +58,7 @@ struct FroehlichPolaron{
 } <: AbstractHamiltonian{T}
     addr::A
     v::T
-    mass::T
+    electron_mass::T
     omega::T
     l::T
     p::T
@@ -70,18 +70,23 @@ end
 function FroehlichPolaron{T}(
     addr::BoseFS{missing,M,SVector{M,AT}};
     v=1,
-    mass=1,
+    electron_mass=1//2,
     omega=1,
     l=1,
     p=0,
     momentum_cutoff=nothing,
     mode_cutoff=nothing,
+    mass=nothing, # deprecated keyword, use `electron_mass` instead
 ) where {T,M,AT}
     if l ≤ 0
         throw(ArgumentError("l must be positive"))
     end
 
-    v, p, mass, omega, l = T.((v, p, mass, omega, l))
+    if !isnothing(mass)
+        @warn "The keyword argument `mass` is deprecated. Use `electron_mass` instead."
+        electron_mass = mass/2
+    end
+    v, p, electron_mass, omega, l = T.((v, p, electron_mass, omega, l))
 
     step = T(2π/M)
     if isodd(M)
@@ -107,19 +112,25 @@ function FroehlichPolaron{T}(
     if _exceed_mode_cutoff(mode_cutoff, addr)
         throw(ArgumentError("Starting address cannot have occupations that exceed mode_cutoff"))
     end
-    return FroehlichPolaron(addr, v, mass, omega, l, p, ks, momentum_cutoff, mode_cutoff)
+    return FroehlichPolaron(addr, v, electron_mass, omega, l, p, ks, momentum_cutoff, mode_cutoff)
 end
 function FroehlichPolaron(
     addr::BoseFS{missing};
     v=1,
-    mass=1,
+    electron_mass=1//2,
     omega=1,
     l=1,
     p=0,
+    mass=nothing, # deprecated keyword, use `electron_mass` instead
     kwargs...
 )
-    T = float(promote_type(typeof(v), typeof(mass), typeof(omega), typeof(l), typeof(p)))
-    return FroehlichPolaron{T}(addr; v=v, mass=mass, omega=omega, l=l, p=p, kwargs...)
+    if !isnothing(mass)
+        @warn "The keyword argument `mass` is deprecated. Use `electron_mass` instead."
+        electron_mass = mass/2
+    end
+
+    T = float(promote_type(typeof(v), typeof(electron_mass), typeof(omega), typeof(l), typeof(p)))
+    return FroehlichPolaron{T}(addr; v=v, electron_mass=electron_mass, omega=omega, l=l, p=p, kwargs...)
 end
 
 function Base.show(io::IO, h::FroehlichPolaron)
@@ -127,7 +138,7 @@ function Base.show(io::IO, h::FroehlichPolaron)
     print(io, "FroehlichPolaron")
     eltype(h) === Float64 || print(io, "{$(eltype(h))}")
     print(io, "($compact_addr; ")
-    print(io, "v=$(h.v), mass=$(h.mass), omega=$(h.omega), l=$(h.l), p=$(h.p), ")
+    print(io, "v=$(h.v), electron_mass=$(h.electron_mass), omega=$(h.omega), l=$(h.l), p=$(h.p), ")
     isnothing(h.momentum_cutoff) || print(io, "momentum_cutoff=$(h.momentum_cutoff), ")
     print(io, "mode_cutoff=$(h.mode_cutoff))")
 end
@@ -144,7 +155,7 @@ LOStructure(::Type{<:FroehlichPolaron{<:Real}}) = IsHermitian()
 function diagonal_element(h::FroehlichPolaron{<:Any,M}, addr::BoseFS{missing,M}) where {M}
     map = onr(addr)
     p_f = dot(h.ks, map)
-    return h.omega * num_particles(addr) + (h.p - p_f)^2 / h.mass
+    return h.omega * num_particles(addr) + (h.p - p_f)^2 / (2 * h.electron_mass)
 end
 
 function num_offdiagonals(::FroehlichPolaron{<:Any,M}, ::BoseFS{missing,M}) where {M}

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -76,6 +76,7 @@ end
         HOCartesianCentralImpurity(BoseFS((1, 0, 0, 0, 0))),
         FroehlichPolaron(BoseFS{missing}(1, 1, 1)),
         FroehlichPolaron(BoseFS{missing}(1, 1, 1); momentum_cutoff=10.0),
+        FroehlichPolaron{Float32}(BoseFS{missing}(1, 1, 1); momentum_cutoff=10.0),
         momentum(HubbardMom1D(BoseFS(0, 1, 5, 1, 0))),
         # HamiltonianProduct
         HubbardReal1D(BoseFS(2,0,0); u=1.0im) * ExtendedHubbardReal1D(BoseFS(2,0,0)),

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1235,6 +1235,10 @@ end
     f3 = FroehlichPolaron(addr3; mode_cutoff=20.0)
 
     @test starting_address(f2) == f2.addr == addr2
+    @test f2 == @test_logs (:warn,) FroehlichPolaron(addr2; mass=1)
+    @test f2 == @test_logs (:warn,) FroehlichPolaron{Float64}(addr2; mass=1)
+    @test_throws ArgumentError FroehlichPolaron{Int}(addr2; mass=1)
+    @test_throws ArgumentError FroehlichPolaron(addr2; mass=1, l=-1)
 
     # test ks vector
     step = (2π/3)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1248,7 +1248,7 @@ end
     @test num_offdiagonals(f2, addr1) == 2*3
 
     # test diagonal_element
-    f2_diag = f2.omega*6 + (1/f2.mass) * (f2.p - dot(f2.ks, onr(addr2)))^2
+    f2_diag = f2.omega*6 + (1/f2.two_m) * (f2.p - dot(f2.ks, onr(addr2)))^2
     @test diagonal_element(f2, addr2) == f2_diag
 
     # test offdiagonal element


### PR DESCRIPTION
This PR changes some of the internals to allow compiling the evaluations of Hamiltonians on GPUs. Previously this was blocked by the hard coded use `Float64` number types into the `excitation` function. This PR allows passing through the required number type.

## New features
- `excitation` accepts floating point type as argument to define the type for the returned value.
- `FroehlichPolaron` now can be required to use `Float32` throughout.
## Changed behaviour
- keyword `mass` renamed to `two_m` in `FroehlichPolaron`, deprecated `mass`.