### PR TITLE
Add a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix mystery allocation in allocation testing ([#395])
 
 ## Older versions
-For changes prior to [v0.18.0] see the [list of releases](https://github.com/RimuQMC/Rimu.jl/releases) on GitHub.
+For changes prior to [v0.18.0](v0180---2026-08-13) see the [list of releases](https://github.com/RimuQMC/Rimu.jl/releases) on GitHub.
 
 ## Instructions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-* Pass custom external potential to HubbardRealSpace [399], [400]
+* Pass custom external potential to HubbardRealSpace ([399], [400])
 * Restrict number type in `FroehlichPolaron` [405]
 
 ### Deprecated
 * Keyword `mass` in `FroehlichPolaron` renamed to `two_m` [405]
 
 ### Other changes
-* Documentation update [398], [407]
+* Documentation update ([398], [407])
 * `excitation` accepts floating point type as argument to define the type for the returned value. [405]
 
 ## Version [v0.18.0] - 2026-08-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix mystery allocation in allocation testing ([#395])
 
 ## Older versions
-For changes prior to [v0.18.0](v0180---2026-08-13) see the [list of releases](https://github.com/RimuQMC/Rimu.jl/releases) on GitHub.
+For changes prior to [v0.18.0](#v0180---2026-08-13) see the [list of releases](https://github.com/RimuQMC/Rimu.jl/releases) on GitHub.
 
 ## Instructions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-* Pass custom external potential to HubbardRealSpace ([#399, #400])
+* Change log ([#409])
+* Pass custom external potential to `HubbardRealSpace` ([#399, #400])
 * Allow restricting the number type in `FroehlichPolaron`; make it compatible with GPU. ([#405])
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Release notes
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+* Pass custom external potential to HubbardRealSpace [399], [400]
+* Restrict number type in `FroehlichPolaron` [405]
+
+### Deprecated
+* Keyword `mass` in `FroehlichPolaron` renamed to `two_m` [405]
+
+### Other changes
+* Documentation update [398], [407]
+* `excitation` accepts floating point type as argument to define the type for the returned value. [405]
+
+## Version [v0.18.0] - 2026-08-13
+
+### Added
+- `SignCorrelator` is a new observable for calculating mutual sign coherence (#397)
+- New mechanism for scaling and shifting Hamiltonians by scalar values based on `ScaledOrShiftedHamiltonian` with public entry points given by `*`, `+`, `VectorInterface.scale`, and `VectorInterface.add`.  [#396]
+
+### Removed
+- `ScaledHamiltonian` is no longer available. [#396]
+
+### Fixed
+- Docs: fix some typos (#393)
+- Fix failing benchmark runs for fork PRs: skip PR comments for fork PRs, modernize output syntax (#394)
+- Fix mystery allocation in allocation testing (#395)
+
+## Older versions
+For changes prior to [v0.18.0] see the [list of releases](https://github.com/RimuQMC/Rimu.jl/releases) on GitHub.
+
+## Instructions
+
+Add all important changes while preparing a PR to the [Unreleased](@ref) section. When preparing a release, move the entries into a new section for the release.
+
+Types of changes (based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/))
+
+* `Added` for new features.
+* `Changed` for changes in existing functionality (breaking changes to API).
+* `Deprecated` for soon-to-be removed features.
+* `Removed` for now removed features.
+* `Fixed` for any bug fixes.
+* `Security` in case of vulnerabilities
+* `Other changes` for changes to internals or documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release notes
+# Change log
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Pass custom external potential to HubbardRealSpace ([#399, #400])
-* Restrict number type in `FroehlichPolaron` ([#405])
+* Allow restring the number type in `FroehlichPolaron`; make it compatible with GPU. ([#405])
 
 ### Deprecated
 * Keyword `mass` in `FroehlichPolaron` renamed to `two_m` ([#405])
 
 ### Other changes
 * Documentation update ([#398, #407])
-* `excitation` accepts floating point type as argument to define the type for the returned value. ([#405])
+* `excitation` accepts floating point type as argument to define the type for the returned value and internal calculations. This permits compiling the function on a GPU with reduced precision arithmetic. ([#405])
 
 ## Version [v0.18.0] - 2026-08-13
 
@@ -45,4 +45,4 @@ Types of changes (based on [Keep a Changelog](https://keepachangelog.com/en/1.1.
 * `Removed` for now removed features.
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities
-* `Other changes` for changes to internals or documentation.
+* `Other changes` for changes to internals or documentation (not API breaking).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ For changes prior to [v0.18.0] see the [list of releases](https://github.com/Rim
 
 ## Instructions
 
-Add all important changes while preparing a PR to the [Unreleased] section. When preparing a release, move the entries into a new section for the release.
+Add all important changes while preparing a PR to the Unreleased section. When preparing a release, move the entries into a new section for the release.
 
 Types of changes (based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Docs: fix some typos ([#393])
-- Fix failing benchmark runs for fork PRs: skip PR comments for fork PRs, modernize output syntax (#394)
+- Fix failing benchmark runs for fork PRs: skip PR comments for fork PRs, modernize output syntax [(#394)]
 - Fix mystery allocation in allocation testing ([#395])
 
 ## Older versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Pass custom external potential to HubbardRealSpace ([#399, #400])
-* Allow restring the number type in `FroehlichPolaron`; make it compatible with GPU. ([#405])
+* Allow restricting the number type in `FroehlichPolaron`; make it compatible with GPU. ([#405])
 
 ### Deprecated
 * Keyword `mass` in `FroehlichPolaron` renamed to `two_m` ([#405])
@@ -16,19 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Documentation update ([#398, #407])
 * `excitation` accepts floating point type as argument to define the type for the returned value and internal calculations. This permits compiling the function on a GPU with reduced precision arithmetic. ([#405])
 
-## Version [v0.18.0] - 2026-08-13
+## v0.18.0 - 2026-08-13
 
 ### Added
-- `SignCorrelator` is a new observable for calculating mutual sign coherence [(#397)]
-- New mechanism for scaling and shifting Hamiltonians by scalar values based on `ScaledOrShiftedHamiltonian` with public entry points given by `*`, `+`, `VectorInterface.scale`, and `VectorInterface.add`.  ([#396])
+* `SignCorrelator` is a new observable for calculating mutual sign coherence ([#397])
+* New mechanism for scaling and shifting Hamiltonians by scalar values based on `ScaledOrShiftedHamiltonian` with public entry points given by `*`, `+`, `VectorInterface.scale`, and `VectorInterface.add`.  ([#396])
 
 ### Removed
-- `ScaledHamiltonian` is no longer available. ([#396])
+* `ScaledHamiltonian` is no longer available. ([#396])
 
 ### Fixed
-- Docs: fix some typos ([#393])
-- Fix failing benchmark runs for fork PRs: skip PR comments for fork PRs, modernize output syntax [(#394)]
-- Fix mystery allocation in allocation testing ([#395])
+* Docs: fix some typos ([#393])
+* Fix failing benchmark runs for fork PRs: skip PR comments for fork PRs, modernize output syntax ([#394])
+* Fix mystery allocation in allocation testing ([#395])
 
 ## Older versions
 For changes prior to [v0.18.0] see the [list of releases](https://github.com/RimuQMC/Rimu.jl/releases) on GitHub.
@@ -40,7 +40,7 @@ Add all important changes while preparing a PR to the Unreleased section. When p
 Types of changes (based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/))
 
 * `Added` for new features.
-* `Changed` for changes in existing functionality (breaking changes to API).
+* `Changed` for changes in existing functionality.
 * `Deprecated` for soon-to-be removed features.
 * `Removed` for now removed features.
 * `Fixed` for any bug fixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,29 +6,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-* Pass custom external potential to HubbardRealSpace ([399], [400])
-* Restrict number type in `FroehlichPolaron` [405]
+* Pass custom external potential to HubbardRealSpace ([#399, #400])
+* Restrict number type in `FroehlichPolaron` ([#405])
 
 ### Deprecated
-* Keyword `mass` in `FroehlichPolaron` renamed to `two_m` [405]
+* Keyword `mass` in `FroehlichPolaron` renamed to `two_m` ([#405])
 
 ### Other changes
-* Documentation update ([398], [407])
-* `excitation` accepts floating point type as argument to define the type for the returned value. [405]
+* Documentation update ([#398, #407])
+* `excitation` accepts floating point type as argument to define the type for the returned value. ([#405])
 
 ## Version [v0.18.0] - 2026-08-13
 
 ### Added
-- `SignCorrelator` is a new observable for calculating mutual sign coherence (#397)
-- New mechanism for scaling and shifting Hamiltonians by scalar values based on `ScaledOrShiftedHamiltonian` with public entry points given by `*`, `+`, `VectorInterface.scale`, and `VectorInterface.add`.  [#396]
+- `SignCorrelator` is a new observable for calculating mutual sign coherence [(#397)]
+- New mechanism for scaling and shifting Hamiltonians by scalar values based on `ScaledOrShiftedHamiltonian` with public entry points given by `*`, `+`, `VectorInterface.scale`, and `VectorInterface.add`.  ([#396])
 
 ### Removed
-- `ScaledHamiltonian` is no longer available. [#396]
+- `ScaledHamiltonian` is no longer available. ([#396])
 
 ### Fixed
-- Docs: fix some typos (#393)
+- Docs: fix some typos ([#393])
 - Fix failing benchmark runs for fork PRs: skip PR comments for fork PRs, modernize output syntax (#394)
-- Fix mystery allocation in allocation testing (#395)
+- Fix mystery allocation in allocation testing ([#395])
 
 ## Older versions
 For changes prior to [v0.18.0] see the [list of releases](https://github.com/RimuQMC/Rimu.jl/releases) on GitHub.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ For changes prior to [v0.18.0] see the [list of releases](https://github.com/Rim
 
 ## Instructions
 
-Add all important changes while preparing a PR to the [Unreleased](@ref) section. When preparing a release, move the entries into a new section for the release.
+Add all important changes while preparing a PR to the [Unreleased] section. When preparing a release, move the entries into a new section for the release.
 
 Types of changes (based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/))
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Rimu"
 uuid = "c53c40cc-bd84-11e9-2cf4-a9fde2b9386e"
-version = "0.18.0"
+version = "0.18.1-dev"
 authors = ["Joachim Brand <j.brand@massey.ac.nz>"]
 
 [deps]


### PR DESCRIPTION
I've started a change log.

The idea is that PR authors update the change log with a concise summary of the important changes in a standardised format. This makes it easier for users and developers to understand what changes happened when, and also makes the release process easier. It is still recommended to thoroughly document the PR in the PR comment section. The change log is meant to only provide a concise summary for providing a quick-to-read overview.